### PR TITLE
Feat: 페이징 기능 구현

### DIFF
--- a/src/main/java/com/example/app/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/example/app/comment/dto/CommentResponseDto.java
@@ -22,8 +22,8 @@ public class CommentResponseDto {
         this.id = comment.getId();
         this.content = comment.getContent();
         this.userName = comment.getUserInfo().getUserName();
-        this.createdAt = comment.getCreatedAt().format(FORMATTER);  // yyyy-MM-dd 형식 변환
-        this.updatedAt = comment.getUpdatedAt().format(FORMATTER);  // yyyy-MM-dd 형식 변환
+        this.createdAt = comment.getCreatedAt().format(FORMATTER);
+        this.updatedAt = comment.getUpdatedAt().format(FORMATTER);
     }
 
     public static CommentResponseDto toDto(Comment comment){

--- a/src/main/java/com/example/app/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/app/schedule/controller/ScheduleController.java
@@ -6,11 +6,10 @@ import com.example.app.schedule.service.ScheduleService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,9 +29,12 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ScheduleResponseDto>> findAllSchedules(){
-        List<ScheduleResponseDto> schedules = scheduleService.findAllSchedules();
-        return new ResponseEntity<>(schedules, HttpStatus.OK);
+    public ResponseEntity<Page<ScheduleResponseDto>> findAllSchedules(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        Page<ScheduleResponseDto> allSchedules = scheduleService.findAllSchedules(page, size);
+        return new ResponseEntity<>(allSchedules, HttpStatus.OK);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/example/app/schedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/app/schedule/dto/ScheduleResponseDto.java
@@ -4,6 +4,8 @@ import com.example.app.schedule.entity.Schedule;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.format.DateTimeFormatter;
+
 @Getter
 @RequiredArgsConstructor
 public class ScheduleResponseDto {
@@ -11,10 +13,21 @@ public class ScheduleResponseDto {
     private final Long id;
     private final String title;
     private final String content;
+    private final int commentCount;
     private final String userName;
+    private final String createdAt;
+    private final String updatedAt;
 
-    public static ScheduleResponseDto toDto(Schedule schedule){
-        return new ScheduleResponseDto(schedule.getId(), schedule.getTitle(), schedule.getContent(), schedule.getUserInfo().getUserName());
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public ScheduleResponseDto(Schedule schedule) {
+        this.id = schedule.getId();
+        this.title = schedule.getTitle();
+        this.content = schedule.getContent();
+        this.commentCount = schedule.getComments().size();
+        this.userName = schedule.getUserInfo().getUserName();
+        this.createdAt = schedule.getCreatedAt().format(FORMATTER);
+        this.updatedAt = schedule.getUpdatedAt().format(FORMATTER);
     }
 
 }

--- a/src/main/java/com/example/app/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/app/schedule/repository/ScheduleRepository.java
@@ -1,6 +1,8 @@
 package com.example.app.schedule.repository;
 
 import com.example.app.schedule.entity.Schedule;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
@@ -16,4 +18,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     }
 
     void deleteByUserInfoId(Long id);
+
+    Page<Schedule> findAllByOrderByUpdatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/com/example/app/userinfo/service/UserInfoService.java
+++ b/src/main/java/com/example/app/userinfo/service/UserInfoService.java
@@ -23,6 +23,7 @@ public class UserInfoService {
     private final PasswordEncoder passwordEncoder;
     private final ScheduleService scheduleService;
 
+    @Transactional
     public UserInfoResponseDto signUp(String userName, String email, String password) {
         String encodedPassword = passwordEncoder.encode(password);
         UserInfo userInfo = new UserInfo(userName, email, encodedPassword);
@@ -30,10 +31,12 @@ public class UserInfoService {
         return new UserInfoResponseDto(newUser.getId(), newUser.getUserName(), newUser.getEmail());
     }
 
+    @Transactional(readOnly = true)
     public List<UserInfoResponseDto> findAllUsers() {
         return userInfoRepository.findAll().stream().map(UserInfoResponseDto::toDto).toList();
     }
 
+    @Transactional(readOnly = true)
     public UserInfoResponseDto findUserInfoById(Long id) {
         UserInfo findUser = userInfoRepository.findUserInfosByIdOrElseThrow(id);
         return new UserInfoResponseDto(findUser.getId(), findUser.getUserName(), findUser.getEmail());


### PR DESCRIPTION
- 일정 전체 조회 부분에 적용(findAllSchedules)
- Spring Data JPA의 Pageable, Page 인터페이스 활용 -> ScheduleRepository 선언, Service에서 구현 -> ScheduleController에서 쿼리파라미터로 요청
- 페이징된 응답 필드 -> 일정 제목, 내용, 댓글수, 작성일, 수정일, 작성자
- Default 페이지 크기는 10으로 적용
- 일정의 수정일을 기준으로 내림차순 정렬